### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/syahmiharith/ELMO/security/code-scanning/1](https://github.com/syahmiharith/ELMO/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow or the specific job. The minimal starting point recommended by CodeQL is `contents: read`, which allows the workflow to read repository contents but not write to them. If the workflow requires additional permissions (e.g., to create pull requests or issues), you can add those as needed. In this case, the workflow uses the `GITHUB_TOKEN` for deployment, but the Firebase deploy action does not require write access to repository contents, so `contents: read` is sufficient. The best place to add this is at the job level (under `build-and-deploy:`), or at the root of the workflow (above `jobs:`) if you want it to apply to all jobs. Since there is only one job, either location is fine, but job-level is slightly more precise.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
