### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -220,6 +220,9 @@ jobs:
 
   notify:
     name: Notify Deployment Status
+    permissions:
+      issues: write
+      contents: read
     runs-on: ubuntu-latest
     needs: [deploy-production]
     if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Potential fix for [https://github.com/syahmiharith/ELMO/security/code-scanning/5](https://github.com/syahmiharith/ELMO/security/code-scanning/5)

To fix the problem, add a `permissions` block to the `notify` job (starting at line 221). The minimal required permission for this job is the ability to write comments on issues or pull requests. Since the job uses `github.rest.issues.createComment`, and the context may be a push event (not a PR), the safest minimal permission is `issues: write`. If you want to be even more restrictive and only allow commenting on PRs, use `pull-requests: write`, but since the job is triggered on push to `main`, `issues: write` is more appropriate. Add the following block under the `name` key for the `notify` job:

```yaml
permissions:
  issues: write
  contents: read
```

The `contents: read` permission is often required for basic actions like checking out code, but in this job, it is not strictly necessary. However, it is a safe minimal default. Place this block at line 223, after `name: Notify Deployment Status` and before `runs-on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
