### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI/CD Pipeline
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/syahmiharith/ELMO/security/code-scanning/2](https://github.com/syahmiharith/ELMO/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/ci-cd.yml`. The best way is to add it at the root level, so it applies to all jobs unless overridden. For most CI/CD jobs (linting, security scanning, building, and testing), the minimal required permission is `contents: read`. If any job requires additional permissions (e.g., for deployment or creating pull requests), you can override the permissions block for that job. In this case, you should add the following block after the workflow name and before the `on:` block:

```yaml
permissions:
  contents: read
```

This change should be made at the top of the file, right after the `name:` line and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
