### PR TITLE
Potential fix for code scanning alert no. 7: Creating biased random numbers from a cryptographically secure source

### DIFF
--- a/functions/src/utils/tickets/security.ts
+++ b/functions/src/utils/tickets/security.ts
@@ -17,15 +17,20 @@ import { securityConfig } from '../../config/function-config';
  */
 export function generateSecureTicketCode(length = securityConfig.secureCodeCharSet.length): string {
     const allowedChars = securityConfig.secureCodeCharSet;
-    const randomBytes = crypto.randomBytes(length);
-
+    const charSetLength = allowedChars.length;
     let result = '';
-    for (let i = 0; i < length; i++) {
-        // Map random bytes to our allowed character set
-        const randomIndex = randomBytes[i] % allowedChars.length;
+    // Calculate the largest multiple of charSetLength less than 256
+    const maxValidByte = Math.floor(256 / charSetLength) * charSetLength;
+    let generated = 0;
+    while (generated < length) {
+        const byte = crypto.randomBytes(1)[0];
+        if (byte >= maxValidByte) {
+            continue; // Discard biased byte
+        }
+        const randomIndex = byte % charSetLength;
         result += allowedChars.charAt(randomIndex);
+        generated++;
     }
-
     return result;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/syahmiharith/ELMO/security/code-scanning/7](https://github.com/syahmiharith/ELMO/security/code-scanning/7)

To fix the problem, we need to ensure that each character in the generated code is selected uniformly from the allowed character set, without bias. The best way to do this is to discard any random byte that would introduce bias. Specifically, for each character, we should generate random bytes until we get a value less than the largest multiple of `allowedChars.length` that is less than or equal to 256 (i.e., `Math.floor(256 / allowedChars.length) * allowedChars.length`). This ensures that when we take the modulo, each index is equally likely. The fix should be applied to the `generateSecureTicketCode` function in `functions/src/utils/tickets/security.ts`, replacing the current loop with a rejection sampling approach.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
